### PR TITLE
fix code smell

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -179,8 +179,19 @@ func addMetrics(ctx context.Context, cfg *rest.Config) {
 
 	// Add to the below struct any other metrics ports you want to expose.
 	servicePorts := []v1.ServicePort{
-		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
-		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
+		{
+			Port:       metricsPort,
+			Name:       metrics.OperatorPortName,
+			Protocol:   v1.ProtocolTCP,
+			TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort},
+		},
+
+		{
+			Port:       operatorMetricsPort,
+			Name:       metrics.CRPortName,
+			Protocol:   v1.ProtocolTCP,
+			TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort},
+		},
 	}
 
 	// Create Service object to expose the metrics port(s).
@@ -208,9 +219,10 @@ func addMetrics(ctx context.Context, cfg *rest.Config) {
 // serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
 // It serves those metrics on "http://metricsHost:operatorMetricsPort".
 func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
-	// The function below returns a list of filtered operator/CR specific GVKs. For more control, override the GVK list below
-	// with your own custom logic. Note that if you are adding third party API schemas, probably you will need to
-	// customize this implementation to avoid permissions issues.
+	// The function below returns a list of filtered operator/CR specific GVKs.
+	// For more control, override the GVK list below with your own custom logic.
+	// Note that if you are adding third party API schemas, probably you will
+	// need tocustomize this implementation to avoid permissions issues.
 	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
 	if err != nil {
 		return err

--- a/pkg/controller/endpointmetrics/endpointmetrics_controller.go
+++ b/pkg/controller/endpointmetrics/endpointmetrics_controller.go
@@ -27,8 +27,9 @@ var log = logf.Log.WithName("controller_endpointmetrics")
 * business logic.  Delete these comments after modifying this file.*
  */
 
-// Add creates a new EndpointMetrics Controller and adds it to the Manager. The Manager will set fields on the Controller
-// and Start it when the Manager is Started.
+// Add creates a new EndpointMetrics Controller and adds it to the Manager.
+// The Manager will set fields on the Controller and Start it when the Manager
+// is Started.
 func Add(mgr manager.Manager) error {
 	return add(mgr, newReconciler(mgr))
 }
@@ -52,7 +53,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// TODO(user): Modify this to be the types you create that are owned by the primary resource
+	// Modify this to be the types you create that are owned by the primary resource
 	// Watch for changes to secondary resource Pods and requeue the owner EndpointMetrics
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
@@ -78,7 +79,7 @@ type ReconcileEndpointMetrics struct {
 
 // Reconcile reads that state of the cluster for a EndpointMetrics object and makes changes based on the state read
 // and what is in the EndpointMetrics.Spec
-// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
+// Modify this Reconcile function to implement your Controller logic.  This example creates
 // a Pod as an example
 // Note:
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or


### PR DESCRIPTION
fix the following code smells:
- split long code line
- remove `TODO` tag